### PR TITLE
I don't see why the alignment is the min

### DIFF
--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -47,7 +47,7 @@ struct FallbackAllocator(Primary, Fallback)
     /**
     The alignment offered is the minimum of the two allocators' alignment.
     */
-    enum uint alignment = min(Primary.alignment, Fallback.alignment);
+    enum uint alignment = gdc(ePrimary.alignment, Fallback.alignment);
 
     /**
     Allocates memory trying the primary allocator first. If it returns $(D


### PR DESCRIPTION
Probably I'm wrong here.
You use min to compute the new alignment. I believe you need to use the greatest
common divisor. Let me explain why.
Alignment means (making sure we agree on definitions here) that the pointers are
aligned, i.e., an alignment of `2` requires that `ptr % 2 == 0` for each ptr
returned by the allocator. Now consider one allocator with an alignment of 2 and
another with an alignment of `3`. Then the FallbackAllocator has an alignment of
`1`. Because `1` is the greatest that satisfies both allocator alignments.