### PR TITLE
Implemented _aligned_alloc functions for the DigitalMars version

### DIFF
--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -101,7 +101,7 @@ version (Windows)
 {
     // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
     // functions family (snn.lib)
-    version(DigitalMars)
+    version(CRuntime_DigitalMars)
     {
         // Helper to cast the infos written before the aligned pointer
         // this header keeps track of the size (required to realloc) and of 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -308,37 +308,42 @@ version(CRuntime_DigitalMars) unittest
 {
     void* m;
         
-    m = _aligned_malloc(16,0x10);
-    if(m){
+    m = _aligned_malloc(16, 0x10);
+    if (m)
+    {
         assert((m.addr & 0xF) == 0);
         _aligned_free(m);
     }
     
-    m = _aligned_malloc(16,0x100);
-    if(m){
+    m = _aligned_malloc(16, 0x100);
+    if (m)
+    {
         assert((m.addr & 0xFF) == 0);
         _aligned_free(m);
     }
 
-    m = _aligned_malloc(16,0x1000);
-    if(m){
+    m = _aligned_malloc(16, 0x1000);
+    if (m)
+    {
         assert((m.addr & 0xFFF) == 0);  
         _aligned_free(m);
     }
     
-    m = _aligned_malloc(16,0x10);
-    if(m){
+    m = _aligned_malloc(16, 0x10);
+    if (m)
+    {
         assert((cast(size_t)m & 0xF) == 0);
-        m = _aligned_realloc(m,32,0x10000);
-        assert((m.addr & 0xFFFF) == 0);
+        m = _aligned_realloc(m, 32, 0x10000);
+        if (m) assert((m.addr & 0xFFFF) == 0);
         _aligned_free(m);
     }
     
-    m = _aligned_malloc(8,0x10);
-    if(m){
+    m = _aligned_malloc(8, 0x10);
+    if (m)
+    {
         *cast(ulong*) m = 0X01234567_89ABCDEF;
-        m = _aligned_realloc(m,0x800,0x1000);
-        assert(*cast(ulong*) m == 0X01234567_89ABCDEF); 
+        m = _aligned_realloc(m, 0x800, 0x1000);
+        if (m) assert(*cast(ulong*) m == 0X01234567_89ABCDEF); 
         _aligned_free(m);
     }     
 }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -165,7 +165,7 @@ version (Windows)
             return alignedPtr;        
         }
         
-        void _aligned_free(void *ptr)
+        private void _aligned_free(void *ptr)
         {
             import std.c.stdlib: free;
             if (!ptr) return;

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -99,9 +99,88 @@ unittest
 version (Posix) private extern(C) int posix_memalign(void**, size_t, size_t);
 version (Windows)
 {
-    private extern(C) void* _aligned_malloc(size_t, size_t);
-    private extern(C) void _aligned_free(void *memblock);
-    private extern(C) void* _aligned_realloc(void *, size_t, size_t);
+    // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
+    // functions family (snn.lib)
+    version(DigitalMars)
+    {
+        // Helper to cast the infos written before the aligned pointer
+        // this header keeps track of the size (required to realloc) and of 
+        // the base ptr (required to free).
+        private struct AlignInfo
+        {   
+            void* basePtr; 
+            size_t size;
+            static AlignInfo* opCall(void* ptr)
+            {
+                return cast(AlignInfo*) (ptr - AlignInfo.sizeof);
+            } 
+        }
+        
+        private void* _aligned_malloc(size_t size, size_t alignment)
+        {
+            import std.c.stdlib: malloc;
+            size_t offset = alignment + size_t.sizeof * 2 - 1;
+            
+            // unaligned chunk
+            void* basePtr = malloc(size + offset);
+            if (!basePtr) return null;
+            
+            // get aligned location within the chunk
+            void* alignedPtr = cast(void**)((cast(size_t)(basePtr) + offset) & ~(alignment - 1));
+            
+            // write the header before the aligned pointer
+            AlignInfo* head = AlignInfo(alignedPtr);
+            head.basePtr = basePtr;
+            head.size = size;
+              
+            return alignedPtr;      
+        }
+        
+        private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
+        {
+            import std.c.stdlib: malloc, free;
+            import std.c.string: memcpy;
+            
+            if(!ptr) return _aligned_malloc(size, alignment);
+            
+            // gets the header from the exising pointer
+            AlignInfo* head = AlignInfo(ptr);
+            
+            // backups exising data
+            void* oldData = malloc(head.size);
+            memcpy(oldData, ptr, head.size);
+            
+            // gets a new aligned pointer and restores the backup
+            void* alignedPtr = _aligned_malloc(size, alignment);
+            if (!alignedPtr) 
+            {
+                free(oldData);
+                return null;
+            }
+            memcpy(alignedPtr, oldData, head.size);
+            free(oldData);
+            
+            // frees the old non-aligned chunk
+            free(head.basePtr); 
+            return alignedPtr;        
+        }
+        
+        void _aligned_free(void *ptr)
+        {
+            import std.c.stdlib: free;
+            if (!ptr) return;
+            AlignInfo* head = AlignInfo(ptr);
+            free(head.basePtr);
+        }
+   
+    }
+    // DMD Win 64 bit, uses microsoft standard C library which implements them
+    else
+    {
+        private extern(C) void* _aligned_malloc(size_t, size_t);
+        private extern(C) void _aligned_free(void *memblock);
+        private extern(C) void* _aligned_realloc(void *, size_t, size_t);
+    }
 }
 
 /**

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -126,7 +126,8 @@ version (Windows)
             if (!basePtr) return null;
             
             // get aligned location within the chunk
-            void* alignedPtr = cast(void**)((cast(size_t)(basePtr) + offset) & ~(alignment - 1));
+            void* alignedPtr = cast(void**)((cast(size_t)(basePtr) + offset) 
+                & ~(alignment - 1));
             
             // write the header before the aligned pointer
             AlignInfo* head = AlignInfo(alignedPtr);
@@ -138,7 +139,7 @@ version (Windows)
         
         private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
         {
-            import std.c.stdlib: malloc, free;
+            import std.c.stdlib: free;
             import std.c.string: memcpy;
             
             if(!ptr) return _aligned_malloc(size, alignment);
@@ -146,22 +147,19 @@ version (Windows)
             // gets the header from the exising pointer
             AlignInfo* head = AlignInfo(ptr);
             
-            // backups exising data
-            void* oldData = malloc(head.size);
-            memcpy(oldData, ptr, head.size);
-            
-            // gets a new aligned pointer and restores the backup
+            // gets a new aligned pointer
             void* alignedPtr = _aligned_malloc(size, alignment);
             if (!alignedPtr) 
             {
-                free(oldData);
+                //to https://msdn.microsoft.com/en-us/library/ms235462.aspx
+                //see Return value: in this case the original block is unchanged
                 return null;
             }
-            memcpy(alignedPtr, oldData, head.size);
-            free(oldData);
             
-            // frees the old non-aligned chunk
-            free(head.basePtr); 
+            // copy exising data
+            memcpy(alignedPtr, ptr, head.size);
+            free(head.basePtr);
+            
             return alignedPtr;        
         }
         
@@ -302,4 +300,45 @@ unittest
         128);
     scope(exit) AlignedMallocator.instance.deallocate(buffer);
     //...
+}
+
+version(unittest) version(CRuntime_DigitalMars) 
+    size_t addr(ref void* ptr){return cast(size_t) ptr;}
+version(CRuntime_DigitalMars) unittest
+{
+    void* m;
+        
+    m = _aligned_malloc(16,0x10);
+    if(m){
+        assert((m.addr & 0xF) == 0);
+        _aligned_free(m);
+    }
+    
+    m = _aligned_malloc(16,0x100);
+    if(m){
+        assert((m.addr & 0xFF) == 0);
+        _aligned_free(m);
+    }
+
+    m = _aligned_malloc(16,0x1000);
+    if(m){
+        assert((m.addr & 0xFFF) == 0);  
+        _aligned_free(m);
+    }
+    
+    m = _aligned_malloc(16,0x10);
+    if(m){
+        assert((cast(size_t)m & 0xF) == 0);
+        m = _aligned_realloc(m,32,0x10000);
+        assert((m.addr & 0xFFFF) == 0);
+        _aligned_free(m);
+    }
+    
+    m = _aligned_malloc(8,0x10);
+    if(m){
+        *cast(ulong*) m = 0X01234567_89ABCDEF;
+        m = _aligned_realloc(m,0x800,0x1000);
+        assert(*cast(ulong*) m == 0X01234567_89ABCDEF); 
+        _aligned_free(m);
+    }     
 }


### PR DESCRIPTION
Summary: these functions are not available for DMD windows 32 bit because they miss in snn.lib

See comments in the final PR: https://github.com/D-Programming-Language/phobos/pull/3405#discussion_r37135023